### PR TITLE
Update exp_fam_mixin.py

### DIFF
--- a/alan/exp_fam_mixin.py
+++ b/alan/exp_fam_mixin.py
@@ -179,7 +179,7 @@ class NormalMixin(AbstractMixin):
     @staticmethod
     def mean2conv(Ex, Ex2):
         loc   = Ex 
-        scale = (Ex2 - loc**2).sqrt()
+        scale = (Ex2 - loc**2).sqrt() + 1e-8
         return {'loc': loc, 'scale': scale}
 
     @staticmethod


### PR DESCRIPTION
This should stabilise the calculation of scale for NormalMixIn. (I have not yet checked the other MixIns but at first glance they don't seem to have anywhere an unwanted 0 could pop up.)